### PR TITLE
Improve substitution of links in plain text emails

### DIFF
--- a/Classes/Dmailer.php
+++ b/Classes/Dmailer.php
@@ -1152,7 +1152,7 @@ class Dmailer implements LoggerAwareInterface
 
         $jumpUrlCounter = 1;
         return preg_replace_callback(
-            '/http[s]?:\/\/\S+/',
+            '/http[s]?:\/\/[^\s>]+/',
             function ($urlMatches) use (&$jumpUrlCounter) {
                 $url = $urlMatches[0];
                 if (strpos($url, '&no_jumpurl=1') !== false) {


### PR DESCRIPTION
In plain text emails it is common to use angle brackets as delimiters for links. With this commit the closing angle bracket will no longer be considered a part of the link.